### PR TITLE
[#44] - Add optional post data input to posts

### DIFF
--- a/frontend/src/components/posts/post/PostController.jsx
+++ b/frontend/src/components/posts/post/PostController.jsx
@@ -1,28 +1,29 @@
 // eslint-disable-next-line import/no-cycle
 import PostView from "./PostView"
-import { sampleReply, samplePost } from './mock-data'
+import replyData from './mock-data'
 
 /**
- * Creates a post
- * @prop {number} id 
+ * Creates a post. One of either id or data must be provided
+ * @prop {number} id - optional, data will be fetched using the id
+ * @prop {object} data - optional, use this post data to render the post
  * @prop {boolean} condensed - optional, makes the post take up less space
  * @prop {boolean} showReplies - optional, also renders each 1st level reply to the post
- * @prop {boolean} isReply - optional, used internally to mock data, can be removed later
  */
-const PostController = ({ id, condensed = false, showReplies = false, isReply = false }) => {
-    // add logic to fetch post from the id.
-    let data = samplePost
-    data.id = id
-
-    // for mock purposes only
-    if (isReply) {
-        data = sampleReply
+const PostController = ({ id = 0, data = null, condensed = false, showReplies = false }) => {
+    let postData = data
+    if (id) {
+        // add logic to fetch post from the id.
+        // for mock, we assume that if an id is given its a reply 
+        postData = replyData
+    } else if (!data) {
+        // true if neither id or data is given
+        return <div>Error retrieving post data</div>
     }
 
     return (
         <PostView 
-            condensed={condensed || isReply} 
-            postData={data} 
+            condensed={condensed} 
+            postData={postData} 
             showReplies={showReplies}
         />
     )

--- a/frontend/src/components/posts/post/PostView.jsx
+++ b/frontend/src/components/posts/post/PostView.jsx
@@ -27,9 +27,9 @@ const PostView = ({ postData, condensed, showReplies }) => {
             <div className={classes.interactions}>
                 <Interactions postData={postData} />
             </div>
-            {showReplies && postData.children.map(reply => (
-                <div key={reply.id} className={classes.reply}>
-                    <Post id={reply.id} isReply />
+            {showReplies && postData.children.map(id => (
+                <div key={id} className={classes.reply}>
+                    <Post id={id} condensed />
                 </div> 
             ))}
         </div>

--- a/frontend/src/components/posts/post/mock-data.js
+++ b/frontend/src/components/posts/post/mock-data.js
@@ -1,38 +1,20 @@
 const sampleUserReplier = {
-  id: 1,
-  username: "replier",
-  nickname: "Replier",
-  profilePic: "https://i.imgur.com/PiJAoqO.jpeg",
-};
+    id: 1,
+    username: 'replier',
+    nickname: 'Replier',
+    profilePic: 'https://i.imgur.com/PiJAoqO.jpeg',
+}
 
-const sampleUserPoster = {
-  id: 2,
-  username: "poster",
-  nickname: "Poster",
-  profilePic: "https://i.imgur.com/qZImY9j.jpg",
-};
+const sampleReply = {
+    id: 2,
+    content: 'reply content',
+    author: sampleUserReplier,
+    parent: null,
+    children: [],
+    usersLiked: 2,
+    usersShared: 3,
+    timestamp: 1646627527764,
+    attachments: null,
+}
 
-export const sampleReply = {
-  id: 2,
-  content: "reply content",
-  author: sampleUserReplier,
-  parent: null,
-  children: [],
-  usersLiked: 2,
-  usersShared: 3,
-  timestamp: 1646627527764,
-  attachments: null,
-};
-
-export const samplePost = {
-  id: 1,
-  content:
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ",
-  author: sampleUserPoster,
-  parent: null,
-  children: [2],
-  usersLiked: 1,
-  usersShared: 2,
-  timestamp: 1646627469012,
-  attachments: null,
-};
+export default sampleReply

--- a/frontend/src/pages/post/PostPageController.jsx
+++ b/frontend/src/pages/post/PostPageController.jsx
@@ -1,5 +1,6 @@
 import { useParams } from "react-router-dom"
 import PostPageView from "./PostPageView"
+import postData from './mock-data'
 
 /**
  * This page renders a single post and its replies. It also contains
@@ -9,7 +10,11 @@ const PostPageController = () => {
     // gets the id from the current url 
     const { id } = useParams()
 
-    return <PostPageView id={id} />
+    // for mock purposes only, will need to fetch post from id 
+    // need to add logic for checking if id is a valid number
+    postData.id = parseInt(id, 10)
+
+    return <PostPageView postData={postData} />
 }
 
 export default PostPageController

--- a/frontend/src/pages/post/PostPageView.jsx
+++ b/frontend/src/pages/post/PostPageView.jsx
@@ -3,11 +3,11 @@ import Footer from '../../components/layout/footer/FooterController'
 import Header from '../../components/layout/header/HeaderController'
 import Post  from '../../components/posts/post/PostController'
 
-const PostPageView = ({ id }) => (
+const PostPageView = ({ postData }) => (
     <div className={classes.container}>
         <Header />
         <div className={classes.pageContent} >
-            <Post id={id} showReplies />  
+            <Post data={postData} showReplies />  
         </div>
         <Footer />
     </div>

--- a/frontend/src/pages/post/mock-data.js
+++ b/frontend/src/pages/post/mock-data.js
@@ -1,0 +1,21 @@
+const sampleUserPoster = {
+    id: 2,
+    username: 'poster',
+    nickname: 'Poster',
+    profilePic: 'https://i.imgur.com/qZImY9j.jpg',
+}
+
+const samplePost = {
+    id: 1,
+    content:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ',
+    author: sampleUserPoster,
+    parent: null,
+    children: [2],
+    usersLiked: 1,
+    usersShared: 2,
+    timestamp: 1646627469012,
+    attachments: null,
+}
+
+export default samplePost


### PR DESCRIPTION
# Description:

Summary of changes:
- Post ID is now optional, if a post is given an ID then it will fetch data and use that (currently using sample data if id is given)
- Post data is added as an optional prop, if given then it will render using this data
- One of either ID or data must be given to a post or it will return an error 
- The posts page will now supply post data to a post instead of an id

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [x] My code has been commented
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
