### PR TITLE
[#24] - Alterable theme support via scss variables at root 

### DIFF
--- a/frontend/src/app.module.scss
+++ b/frontend/src/app.module.scss
@@ -1,3 +1,5 @@
+@use '~/src/styles/theme';
+
 .container {
     display: flex;
     flex-direction: column;
@@ -8,5 +10,5 @@ body {
     margin: 0;
     padding: 0;
     height: 100vh;
-    font-family: 'Roboto';
+    background-color: theme.$background;
 }

--- a/frontend/src/components/layout/footer/footer.module.scss
+++ b/frontend/src/components/layout/footer/footer.module.scss
@@ -1,6 +1,10 @@
+@use '~/src/styles/theme';
+
 .container {
     display: flex;
     flex-direction: row;
+    background-color: theme.$primary;
+    color: theme.$onPrimary;
     border-top: 1px solid black;
     min-height: 3rem;
     justify-content: center;

--- a/frontend/src/components/layout/header/header.module.scss
+++ b/frontend/src/components/layout/header/header.module.scss
@@ -1,6 +1,10 @@
+@use '~/src/styles/theme';
+
 .container {
     display: flex;
     flex-direction: row;
+    background-color: theme.$primary;
+    color: theme.$onPrimary;
     border-bottom: 1px solid black;
     min-height: 3rem;
     justify-content: center;

--- a/frontend/src/components/posts/post/post.module.scss
+++ b/frontend/src/components/posts/post/post.module.scss
@@ -1,11 +1,13 @@
+@use '~/src/styles/theme';
+
 .container {
     display: flex;
     flex-direction: column;
     gap: 1rem;
 
     .interactions {
-        border-top: 1px solid lightgray;
-        border-bottom: 1px solid lightgray;
+        border-top: 1px solid theme.$divider;
+        border-bottom: 1px solid theme.$divider;
         padding-top: 0.5rem;
         padding-bottom: 0.5rem;
     }
@@ -17,7 +19,7 @@
         
     .reply {
         padding-bottom: 1rem;
-        border-bottom: 1px solid lightgray;
+        border-bottom: 1px solid theme.$divider;
     }
 }
 

--- a/frontend/src/components/user/simpledetails/simpleuserdetails.module.scss
+++ b/frontend/src/components/user/simpledetails/simpleuserdetails.module.scss
@@ -1,9 +1,11 @@
+@use '~/src/styles/theme';
+
 .container {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    color: black;
+    color: theme.$onBackground;
     text-decoration: none;
     width: 100%;
     height: 100%;
@@ -21,7 +23,7 @@
     justify-content: left;
     gap: 1rem;
     align-items: center;
-    color: black;
+    color: theme.$onBackground;
     text-decoration: none;
     width: 100%;
     height: 100%;

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -1,3 +1,4 @@
+// colour theme
 $primary: #6200EE;
 $primaryVariant: #3700B3;
 $secondary: #03DAC6;
@@ -11,6 +12,21 @@ $onSurface: #000000;
 $onBackground: #000000;
 $onError: #FFFFFF;
 $divider: lightgray;
+
+// font sizes
+$text-xs: 0.75rem;
+$text-sm: 0.875rem;
+$text-base: 1rem;
+$text-lg: 1.125rem;
+$text-xl: 1.25rem;
+$text-2xl: 1.5rem;
+$text-3xl: 1.875rem;
+$text-4xl: 2.25rem;
+$text-5xl: 3rem;
+$text-6xl: 3.75rem;
+$text-7xl: 4.5rem;
+$text-8xl: 6rem;
+$text-9xl: 8rem;
 
 body {
     font-family: 'Roboto', sans-serif;

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -1,0 +1,17 @@
+$primary: #6200EE;
+$primaryVariant: #3700B3;
+$secondary: #03DAC6;
+$secondaryVariant: #018786;
+$surface: #FFFFFF;
+$background: #FFFFFF;
+$error: #B00020;
+$onPrimary: #FFFFFF;
+$onSecondary: #FFFFFF;
+$onSurface: #000000;
+$onBackground: #000000;
+$onError: #FFFFFF;
+$divider: lightgray;
+
+body {
+    font-family: 'Roboto', sans-serif;
+}


### PR DESCRIPTION
# Description:
It would be useful before people start developing pages to have some colors that can be referenced. This PR proposes to add the default material UI colourway as a base for theming the project. These colours can be easily changed at any time and will ensure consistent, extendable styling throughout the frontend.

Any proposed colourways should be sent either as a response to this PR, or sent as a new PR if this is merged.

The theme file:

![image](https://user-images.githubusercontent.com/54062686/157560927-ff4063b9-8af6-4cfb-ba11-9aba36ae2a4d.png)

Example usage:

![image](https://user-images.githubusercontent.com/54062686/157560432-1a1ffc9c-8a24-40c5-bd76-1d30baf94604.png)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [x] My code has been commented
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
