### PR TITLE
[#67] Removed use of secrets for DB login

### DIFF
--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -24,8 +24,8 @@ jobs:
     - uses: mirromutth/mysql-action@v1.1
       with:
         mysql database: 'updog'
-        mysql user: ${{ secrets.db_username }}
-        mysql password: ${{ secrets.db_password }}
+        mysql user: 'updogDev'
+        mysql password: 'password'
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2


### PR DESCRIPTION
Github does not allow secrets to be accessed by workflows triggered from PRs from a fork

# Description:
Please provide a summary of changes made and the relevant issue that has been worked on. Also list any major changes made to project structure/dependencies if applicable

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project
- [ ] My code has been commented
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
