### PR TITLE
[#73] - Use primary colour on header/footer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,14 +17,33 @@ const theme = createTheme({
             main: palette.error,
         },
     },
+    components: {
+        MuiBottomNavigationAction: {
+            styleOverrides: {
+                root: {
+                    color: palette.onPrimary,
+                    '&.Mui-selected': {
+                        color: palette.secondary,
+                    },
+                },
+            },
+        },
+        MuiBottomNavigation: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: palette.primary,
+                },
+            },
+        },
+    },
 })
 
 const App = () => (
-  <ThemeProvider theme={theme}>
-    <div className={classes.container}>
-      <Router />
-    </div>
-  </ThemeProvider>
+    <ThemeProvider theme={theme}>
+        <div className={classes.container}>
+            <Router />
+        </div>
+    </ThemeProvider>
 )
 
 export default App

--- a/frontend/src/components/layout/footer/FooterView.jsx
+++ b/frontend/src/components/layout/footer/FooterView.jsx
@@ -3,55 +3,53 @@ import BottomNavigationAction from '@mui/material/BottomNavigationAction'
 import HomeIcon from '@mui/icons-material/Home'
 import SearchIcon from '@mui/icons-material/Search'
 import NotificationsIcon from '@mui/icons-material/Notifications'
-import { StyledEngineProvider, Badge } from '@mui/material'
+import { Badge } from '@mui/material'
 import { Link } from 'react-router-dom'
 
 import classes from './footer.module.scss'
 
 const FooterView = ({ currentPage, onPageChange, notificationsNumber }) => (
     <div className={classes.container}>
-        <StyledEngineProvider injectFirst>
-            <BottomNavigation
-                showLabels
-                value={currentPage}
-                onChange={onPageChange}
-                className={classes.nav}
-            >
-                <BottomNavigationAction
-                    className={classes.navIcon}
-                    value="/"
-                    label="Home"
-                    icon={<HomeIcon />}
-                    component={Link}
-                    to="/"
-                />
-                <BottomNavigationAction
-                    className={classes.navIcon}
-                    value="/search"
-                    label="Search"
-                    icon={<SearchIcon />}
-                    component={Link}
-                    to="/search"
-                />
-                <BottomNavigationAction
-                    className={classes.navIcon}
-                    value="/notifications"
-                    label="Notifications"
-                    icon={
-                        <Badge
-                            badgeContent={notificationsNumber}
-                            color="error"
-                            max={10}
-                            overlap="circular"
-                        >
-                            <NotificationsIcon />
-                        </Badge>
-                    }
-                    component={Link}
-                    to="/notifications"
-                />
-            </BottomNavigation>
-        </StyledEngineProvider>
+        <BottomNavigation
+            showLabels
+            value={currentPage}
+            onChange={onPageChange}
+            className={classes.nav}
+        >
+            <BottomNavigationAction
+                className={classes.navIcon}
+                value="/"
+                label="Home"
+                icon={<HomeIcon />}
+                component={Link}
+                to="/"
+            />
+            <BottomNavigationAction
+                className={classes.navIcon}
+                value="/search"
+                label="Search"
+                icon={<SearchIcon />}
+                component={Link}
+                to="/search"
+            />
+            <BottomNavigationAction
+                className={classes.navIcon}
+                value="/notifications"
+                label="Notifications"
+                icon={
+                    <Badge
+                        badgeContent={notificationsNumber}
+                        color="error"
+                        max={10}
+                        overlap="circular"
+                    >
+                        <NotificationsIcon />
+                    </Badge>
+                }
+                component={Link}
+                to="/notifications"
+            />
+        </BottomNavigation>
     </div>
 )
 

--- a/frontend/src/components/layout/footer/footer.module.scss
+++ b/frontend/src/components/layout/footer/footer.module.scss
@@ -8,9 +8,9 @@
 }
 
 .nav {
-    background-color: theme.$secondary;
+    background-color: theme.$primary;
 }
 
 .navIcon{
-    color: theme.$primaryVariant;
+    color: theme.$onPrimary;
 }

--- a/frontend/src/components/layout/headercustom/headercustom.module.scss
+++ b/frontend/src/components/layout/headercustom/headercustom.module.scss
@@ -9,7 +9,7 @@
 }
 
 .headerCustom {
-    background-color: theme.$secondary;
+    background-color: theme.$primary;
     color: theme.$secondary;
     justify-content: space-between;
 }
@@ -21,9 +21,9 @@
 }
 
 .headerIcon {
-    color: theme.$primary;
+    color: theme.$onPrimary !important;
 }
 
 .headerText{
-    color: theme.$primary;
+    color: theme.$onPrimary;
 }

--- a/frontend/src/styles/theme.scss
+++ b/frontend/src/styles/theme.scss
@@ -38,4 +38,6 @@ body {
     secondary: $secondary;
     secondaryVariant: $secondaryVariant;
     error: $error;
+    onPrimary: $onPrimary;
+    onSecondary: $onSecondary;
 }


### PR DESCRIPTION
# Description:
Changes header and footer to use the primary colour
Closes #73 

New footer when item is selected
![image](https://user-images.githubusercontent.com/54062686/158008933-6614cd0c-22f8-4143-8934-81678f575893.png)

New header/footer
![image](https://user-images.githubusercontent.com/54062686/158008954-78a77f44-01bd-4b60-b004-679d10fd6d76.png)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project
- [ ] My code has been commented
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
