### PR TITLE
[#168] Fix backend port configuration

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,2 +1,2 @@
-const SERVER_URL = 'http://localhost:8080/api'
+const SERVER_URL = 'http://localhost:8000/api'
 export default SERVER_URL


### PR DESCRIPTION
# Description:

The intent of this pull request is to change the configuration of the frontend project so that it points to port `8000` for the backend (rather than `8080` which is what it is currently).

Closes #168

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project
- [ ] My code has been commented
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
