### PR TITLE
[#155] Implement bio edit popup in user profile

### DIFF
--- a/frontend/src/components/user/BioSetting/BioEditController.jsx
+++ b/frontend/src/components/user/BioSetting/BioEditController.jsx
@@ -1,14 +1,6 @@
 import React from 'react'
 import BioEditView from './BioEditView'
 
-export default function BioEditController({
-    opened,
-    setOpen,
-}){
-    return(
-        <BioEditView
-            opened = {opened}
-            setOpen = {setOpen}
-        />
-    )
+export default function BioEditController({ opened, setOpen }) {
+  return <BioEditView opened={opened} setOpen={setOpen} />
 }

--- a/frontend/src/components/user/BioSetting/BioEditController.jsx
+++ b/frontend/src/components/user/BioSetting/BioEditController.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import BioEditView from './BioEditView'
+
+export default function BioEditController({
+    opened,
+    setOpen,
+}){
+    return(
+        <BioEditView
+            opened = {opened}
+            setOpen = {setOpen}
+        />
+    )
+}

--- a/frontend/src/components/user/BioSetting/BioEditView.jsx
+++ b/frontend/src/components/user/BioSetting/BioEditView.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import {
+    Button, 
+    TextField,
+    Divider, 
+    Dialog, 
+    DialogContent, 
+    Grid,
+    DialogTitle} from '@mui/material'
+import classes from './bioEdit.module.scss'
+
+  export default function BioEditView({
+    opened,
+    setOpen,
+
+  }) {
+    return (
+        <Dialog
+            fullWidth
+            open={opened} 
+            onClose={() => {setOpen(false)
+        }}>
+        <DialogTitle className={classes.title}>Edit Bio</DialogTitle>
+        <DialogContent>
+        <Divider className={classes.divider} variant="middle" />
+        <TextField
+          id="filled-multiline-static"
+          fullWidth
+          multiline
+          rows={4}
+          inputProps={{ maxLength: 150 }}
+          variant="filled"
+        />
+        </DialogContent>
+        <Grid item alignSelf="center">
+            <Button
+                className={classes.saveButton}
+                variant="contained"
+                onClick={() => {setOpen(false)}}>
+                Save
+            </Button>
+        </Grid>
+      </Dialog>
+    )
+  }

--- a/frontend/src/components/user/BioSetting/BioEditView.jsx
+++ b/frontend/src/components/user/BioSetting/BioEditView.jsx
@@ -1,56 +1,61 @@
 import React from 'react'
 import {
-    Button, 
-    TextField,
-    Divider, 
-    Dialog, 
-    DialogContent, 
-    Grid,
-    DialogTitle} from '@mui/material'
+  Button,
+  TextField,
+  Divider,
+  Dialog,
+  DialogContent,
+  Grid,
+  DialogTitle,
+} from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import classes from './bioEdit.module.scss'
 
+export default function BioEditView({ opened, setOpen }) {
+  return (
+    <Dialog
+      fullWidth
+      open={opened}
+      onClose={() => {
+        setOpen(false)
+      }}
+    >
+      <DialogTitle className={classes.title}>
+        Edit Bio
+        <CloseIcon
+          sx={{
+            position: 'absolute',
+            right: 20,
+            top: 20,
+          }}
+          onClick={() => {
+            setOpen(false)
+          }}
+        />
+      </DialogTitle>
 
-  export default function BioEditView({
-    opened,
-    setOpen,
-  }) {
-    return (
-        <Dialog
-            fullWidth
-            open={opened} 
-            onClose={() => {setOpen(false)
-        }}>
-        <DialogTitle className={classes.title}>
-            Edit Bio
-            <CloseIcon 
-                sx={{
-                    position: 'absolute',
-                    right:20,
-                    top:20,
-                }}
-                onClick={() => {setOpen(false)}}/>        
-        </DialogTitle>
-        
-        <DialogContent>
-            <Divider className={classes.divider} variant="middle"/>
-            <TextField
-                id="filled-multiline-static"
-                fullWidth
-                multiline
-                rows={4}
-                inputProps={{ maxLength: 150 }}
-                variant="filled"
-            />
-        </DialogContent>
-        <Grid item alignSelf="center">
-            <Button
-                className={classes.saveButton}
-                variant="contained"
-                onClick={() => {setOpen(false)}}>
-                Save
-            </Button>
-        </Grid>
-      </Dialog>
-    )
-  }
+      <DialogContent>
+        <Divider className={classes.divider} variant="middle" />
+        <TextField
+          id="filled-multiline-static"
+          fullWidth
+          multiline
+          rows={4}
+          inputProps={{ maxLength: 150 }}
+          variant="filled"
+        />
+      </DialogContent>
+      <Grid item alignSelf="center">
+        <Button
+          className={classes.saveButton}
+          variant="contained"
+          onClick={() => {
+            setOpen(false)
+          }}
+        >
+          Save
+        </Button>
+      </Grid>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/user/BioSetting/BioEditView.jsx
+++ b/frontend/src/components/user/BioSetting/BioEditView.jsx
@@ -7,12 +7,13 @@ import {
     DialogContent, 
     Grid,
     DialogTitle} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 import classes from './bioEdit.module.scss'
+
 
   export default function BioEditView({
     opened,
     setOpen,
-
   }) {
     return (
         <Dialog
@@ -20,17 +21,27 @@ import classes from './bioEdit.module.scss'
             open={opened} 
             onClose={() => {setOpen(false)
         }}>
-        <DialogTitle className={classes.title}>Edit Bio</DialogTitle>
+        <DialogTitle className={classes.title}>
+            Edit Bio
+            <CloseIcon 
+                sx={{
+                    position: 'absolute',
+                    right:20,
+                    top:20,
+                }}
+                onClick={() => {setOpen(false)}}/>        
+        </DialogTitle>
+        
         <DialogContent>
-        <Divider className={classes.divider} variant="middle" />
-        <TextField
-          id="filled-multiline-static"
-          fullWidth
-          multiline
-          rows={4}
-          inputProps={{ maxLength: 150 }}
-          variant="filled"
-        />
+            <Divider className={classes.divider} variant="middle"/>
+            <TextField
+                id="filled-multiline-static"
+                fullWidth
+                multiline
+                rows={4}
+                inputProps={{ maxLength: 150 }}
+                variant="filled"
+            />
         </DialogContent>
         <Grid item alignSelf="center">
             <Button

--- a/frontend/src/components/user/BioSetting/bioEdit.module.scss
+++ b/frontend/src/components/user/BioSetting/bioEdit.module.scss
@@ -1,15 +1,15 @@
 @use '~/src/styles/theme';
 
 .title {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .divider {
-    margin-top: 4px;
-    margin-bottom: 4px;
-  }
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
 
 .saveButton {
-    width: 200px;
-    margin-bottom: 8px;
+  width: 200px;
+  margin-bottom: 8px;
 }

--- a/frontend/src/components/user/BioSetting/bioEdit.module.scss
+++ b/frontend/src/components/user/BioSetting/bioEdit.module.scss
@@ -1,0 +1,15 @@
+@use '~/src/styles/theme';
+
+.title {
+    font-weight: bold;
+}
+
+.divider {
+    margin-top: 4px;
+    margin-bottom: 4px;
+  }
+
+.saveButton {
+    width: 200px;
+    margin-bottom: 8px;
+}

--- a/frontend/src/pages/profileSettings/ProfileSettingsView.jsx
+++ b/frontend/src/pages/profileSettings/ProfileSettingsView.jsx
@@ -122,14 +122,15 @@ const ProfileSettingsView = ({
           <p style={{ fontWeight: 'bold' }}>Bio</p>
         </div>
         <div className={classes.right}>
-          <Button variant="text"          
-          onClick={() => {
-            setOpenBioEdit(true)
-          }}>Edit</Button>
-          <BioEditController
-            opened={openBioEdit}
-            setOpen={setOpenBioEdit}
-        />
+          <Button
+            variant="text"
+            onClick={() => {
+              setOpenBioEdit(true)
+            }}
+          >
+            Edit
+          </Button>
+          <BioEditController opened={openBioEdit} setOpen={setOpenBioEdit} />
         </div>
       </div>
       <p className={classes.subtext} style={{ marginBottom: '14px' }}>

--- a/frontend/src/pages/profileSettings/ProfileSettingsView.jsx
+++ b/frontend/src/pages/profileSettings/ProfileSettingsView.jsx
@@ -7,6 +7,7 @@ import Footer from '../../components/layout/footer/FooterController'
 import HeaderCustom from '../../components/layout/headercustom/HeaderCustomController'
 import classes from './profilesettings.module.scss'
 import BannerSettingController from '../../components/user/BannerSetting/BannerSettingController'
+import BioEditController from '../../components/user/BioSetting/BioEditController'
 
 // TODO: Remove when is ready
 const mock = [
@@ -39,6 +40,7 @@ const ProfileSettingsView = ({
   handleAvatarClose,
 }) => {
   const [openDialog, setOpenDialog] = useState(false)
+  const [openBioEdit, setOpenBioEdit] = useState(false)
 
   return (
     <div>
@@ -120,7 +122,14 @@ const ProfileSettingsView = ({
           <p style={{ fontWeight: 'bold' }}>Bio</p>
         </div>
         <div className={classes.right}>
-          <Button variant="text">Edit</Button>
+          <Button variant="text"          
+          onClick={() => {
+            setOpenBioEdit(true)
+          }}>Edit</Button>
+          <BioEditController
+            opened={openBioEdit}
+            setOpen={setOpenBioEdit}
+        />
         </div>
       </div>
       <p className={classes.subtext} style={{ marginBottom: '14px' }}>


### PR DESCRIPTION
# Description:
Implement the pop up dialog when clicking edit button in users' profile page, the diaglog allows users to type in text and save it for display. This dialog includes a title, a close icon, a textfield and a button to save the changed bio. Currently the save button is equivalent to quit operation and waiting for backend endpoints to save that bio text into database.
![image](https://user-images.githubusercontent.com/69098495/160277559-9eb4ca4c-1ed5-4321-b24a-8a5c50a6707c.png)




### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [ ] My code has been commented
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
