### PR TITLE
[#165] Add Search Endpoint

### DIFF
--- a/backend/__tests__/search.js
+++ b/backend/__tests__/search.js
@@ -1,0 +1,155 @@
+import request from 'supertest'
+import server from '../server/index'
+import Helper from './helper/helper'
+
+const assert = require('assert')
+
+describe('Search', () => {
+  describe('GET /search', () => {
+    describe('When searching for an existing user', () => {
+      it('Should return a 200 status response', async () => {
+        const user = await Helper.createUser(
+          'Pete Davidson',
+          'password',
+          'pete@gmail.com'
+        )
+
+        const response = await request(server)
+          .get('/api/search/')
+          .query({ query: 'Pete', type: 'people' })
+
+        assert.equal(response.statusCode, 200)
+        expect(response.body[0].id).toBe(user.id)
+        expect(response.body[0].username).toBe(user.username)
+      })
+    })
+
+    describe('When searching for existing users with similiar names', () => {
+      it('Should return a 200 status response', async () => {
+        const user1 = await Helper.createUser(
+          'Pink Unicorn',
+          'password',
+          'pink.unicorn@gmail.com'
+        )
+        const user2 = await Helper.createUser(
+          'Green Unicorn',
+          'password',
+          'green.unicorn@gmail.com'
+        )
+
+        const response = await request(server)
+          .get('/api/search/')
+          .query({ query: 'Unicorn', type: 'people' })
+
+        assert.equal(response.statusCode, 200)
+        expect(response.body[0].id).toBe(user1.id)
+        expect(response.body[0].username).toBe(user1.username)
+        expect(response.body[1].id).toBe(user2.id)
+        expect(response.body[1].username).toBe(user2.username)
+      })
+    })
+
+    describe('When searching for non-existing user', () => {
+      it('Should return a 200 status response', async () => {
+        const response = await request(server)
+          .get('/api/search/')
+          .query({ query: 'abcdefgh', type: 'people' })
+
+        assert.equal(response.statusCode, 200)
+        assert.equal(response.body.length, 0)
+      })
+    })
+
+    describe('When searching for an existing post', () => {
+      it('Should return a 200 status response', async () => {
+        const user = await Helper.createUser(
+          'Kim Kardashian',
+          'password',
+          'kim.kardashian@gmail.com'
+        )
+
+        const earlyPost = await Helper.createPost(
+          'Hi my name is Kim Kardashian West',
+          user.id,
+          null,
+          '2021-03-13 04:56:53'
+        )
+        const laterPost = await Helper.createPost(
+          'Hi my name is Kim Kardashian',
+          user.id,
+          null,
+          '2021-03-13 04:57:00'
+        )
+
+        const response = await request(server)
+          .get('/api/search/')
+          .query({ query: 'Kim', type: 'latest' })
+
+        assert.equal(response.statusCode, 200)
+        expect(response.body[0].id).toBe(laterPost.id)
+        expect(response.body[0].content).toBe(laterPost.text_content)
+        expect(response.body[1].id).toBe(earlyPost.id)
+        expect(response.body[1].content).toBe(earlyPost.text_content)
+      })
+    })
+
+    describe('When searching for existing top posts', () => {
+      it('Should return a 200 status response', async () => {
+        const user1 = await Helper.createUser(
+          'Taylor Swift',
+          'password',
+          'taylor.swift@gmail.com'
+        )
+        const user2 = await Helper.createUser(
+          'Olivia Rodrigo',
+          'password',
+          'olivia.rodrigo@gmail.com'
+        )
+
+        const mostLikedPost = await Helper.createPost(
+          'I am very tired',
+          user1.id,
+          null,
+          '2021-03-13 04:56:53'
+        )
+        const leastLikedPost = await Helper.createPost(
+          'I am tired',
+          user1.id,
+          null,
+          '2021-03-13 04:57:00'
+        )
+
+        await Helper.likePost(mostLikedPost.id, user2.id)
+
+        const response = await request(server)
+          .get('/api/search/')
+          .query({ query: 'tired', type: 'top' })
+
+        assert.equal(response.statusCode, 200)
+        expect(response.body[0].id).toBe(mostLikedPost.id)
+        expect(response.body[0].content).toBe(mostLikedPost.text_content)
+        expect(response.body[1].id).toBe(leastLikedPost.id)
+        expect(response.body[1].content).toBe(leastLikedPost.text_content)
+      })
+    })
+
+    describe('When searching for non-existing posts', () => {
+      it('Should return a 200 status response', async () => {
+        const response = await request(server)
+          .get('/api/search/')
+          .query({ query: 'wefhnrkevgkdsnv', type: 'top' })
+
+        assert.equal(response.statusCode, 200)
+        assert.equal(response.body.length, 0)
+      })
+    })
+
+    describe('When searching with missing query', () => {
+      it('Should return a 400 Bad Request status response', async () => {
+        const response = await request(server).get('/api/search/')
+
+        assert.equal(response.statusCode, 400)
+      })
+    })
+  })
+})

--- a/backend/server/controllers/index.js
+++ b/backend/server/controllers/index.js
@@ -2,5 +2,6 @@ import * as user from './user'
 import * as posts from './posts'
 import * as test from './testapi'
 import * as tags from './tags'
+import * as search from './search'
 
-export { user, posts, test, tags }
+export { user, posts, test, tags, search }

--- a/backend/server/controllers/search.js
+++ b/backend/server/controllers/search.js
@@ -14,6 +14,7 @@ type - the type of data to search for: top/latest/people
         People returns any users who match the search
 Response Codes:
 200 OK when the data has been successfully found.
+400 BAD REQUEST when one of the query parameters is missing
 500 INTERNAL SERVER ERROR for everything else.
 */
 export const search = async (req, res) => {

--- a/backend/server/controllers/search.js
+++ b/backend/server/controllers/search.js
@@ -1,0 +1,95 @@
+import PostDTO from '../../dto/posts'
+import UserDTO from '../../dto/users'
+import models from '../../database/models'
+
+const Sequelize = require('sequelize')
+
+/*
+Does not require authentication.
+Query parameters:
+query - the search query
+type - the type of data to search for: top/latest/people
+        Top returns search results sorted by their likes
+        Latest returns most recent search results
+        People returns any users who match the search
+Response Codes:
+200 OK when the data has been successfully found.
+500 INTERNAL SERVER ERROR for everything else.
+*/
+export const search = async (req, res) => {
+  try {
+    const { query } = req
+
+    if (!query.query) {
+      res.status(400).send('Query parameter "query" required')
+      return
+    } else if (!query.type) {
+      res.status(400).send('Query parameter "type" required')
+      return
+    }
+
+    if (query.type == 'people') {
+      const users = await getUsersByQuery(query.query)
+      const userDtos = await generateUserDtos(users)
+      res.status(200).send(userDtos)
+    } else {
+      const posts = await getPostsByQuery(query.query)
+      const postDtos = await generatePostDtos(posts, query.type)
+      res.status(200).send(postDtos)
+    }
+  } catch (error) {
+    res.status(500).send(error)
+  }
+}
+
+const getUsersByQuery = async (query) => {
+  return await models.users.findAll({
+    where: {
+      [Sequelize.Op.or]: [
+        { username: { [Sequelize.Op.like]: '%' + query + '%' } },
+        { email: { [Sequelize.Op.like]: '%' + query + '%' } },
+        { nickname: { [Sequelize.Op.like]: '%' + query + '%' } },
+      ],
+    },
+    raw: true,
+  })
+}
+
+const generateUserDtos = async (users) => {
+  const userDtos = []
+  await Promise.all(
+    users.map(async (user) => {
+      const userDto = await UserDTO.convertToDto(user)
+      userDtos.push(userDto)
+    })
+  )
+  return userDtos
+}
+
+const getPostsByQuery = async (query) => {
+  return await models.posts.findAll({
+    where: {
+      text_content: { [Sequelize.Op.like]: '%' + query + '%' },
+    },
+    order: [['createdAt', 'DESC']],
+    raw: true,
+  })
+}
+
+const generatePostDtos = async (posts, sortBy) => {
+  const postDtos = []
+  await Promise.all(
+    posts.map(async (post) => {
+      const postDto = await PostDTO.convertToDto(post)
+      postDtos.push(postDto)
+    })
+  )
+
+  // Posts are by default sorted by their createdAt time
+  if (sortBy === 'top') {
+    postDtos.sort((a, b) => {
+      return b.usersLiked - a.usersLiked
+    })
+  }
+  return postDtos
+}

--- a/backend/server/routes/index.js
+++ b/backend/server/routes/index.js
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 
-import { user, posts, test, tags } from '../controllers'
+import { user, posts, test, tags, search } from '../controllers'
 
 const router = Router()
 
@@ -53,6 +53,11 @@ router.route('/posts/:id/interactions').get(posts.getInteractedUsers)
 TAGS
 */
 router.route('/tags').post(tags.createTag)
+
+/*
+SEARCH
+*/
+router.route('/search').get(search.search)
 
 /*
 TESTING

--- a/backend/specs/swagger.yaml
+++ b/backend/specs/swagger.yaml
@@ -685,6 +685,35 @@ paths:
                 $ref: '#/components/schemas/Posts'
       security:
         - bearerAuth: []
+  /search:
+    get:
+      tags:
+        - Search
+      summary: Searches for posts, topics, and users
+      description: ''
+      operationId: search
+      parameters:
+        - in: query
+          name: query
+          description: 'The search query.'
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: type
+          description: 'The type of data to search for: top/latest/people.'
+          required: true
+          schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '500':
+          description: Internal Server Error
 components:
   schemas:
     Posts:


### PR DESCRIPTION
# Description:
Adds a new endpoint for searching for posts and users. This also includes adding corresponding swagger documentation and tests.

GET /api/search?query=&type=
Query parameters:
-   query - the search query
-   type - what type of data to search for: top/latest/people
When type is top, posts returned are sorted by their number of likes
When type is latest, posts returned are sorted by time created
When type is people, the data returned is users that match the search query

Closes #165 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [x] My code has been commented
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
