### PR TITLE
[#153] Implement Confirmation Popup Component

### DIFF
--- a/frontend/src/components/popup/confirmation/ConfirmationPopUpController.jsx
+++ b/frontend/src/components/popup/confirmation/ConfirmationPopUpController.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import ConfirmationPopUpView from './ConfirmationPopUpView'
+
+/**
+ * Creates a popup for confirmation of a given action - usually yes or no
+ */
+
+const ConfirmationPopUpController = ({ query, method }) => {
+  const [open, setOpen] = useState(false)
+
+  const onDecline = () => {
+    setOpen(false)
+  }
+
+  return (
+    <ConfirmationPopUpView
+      query={query}
+      method={method}
+      open={open}
+      onDecline={onDecline}
+    />
+  )
+}
+
+export default ConfirmationPopUpController

--- a/frontend/src/components/popup/confirmation/ConfirmationPopUpController.jsx
+++ b/frontend/src/components/popup/confirmation/ConfirmationPopUpController.jsx
@@ -2,11 +2,13 @@ import { useState } from 'react'
 import ConfirmationPopUpView from './ConfirmationPopUpView'
 
 /**
- * Creates a popup for confirmation of a given action - usually yes or no
+ * Creates a popup for confirmation of a given action.
+ * @prop question - the question being asked by the confirmation popup.
+ * @prop onAccept - method passed through from parent component for the 'Yes' button to action.
  */
 
-const ConfirmationPopUpController = ({ query, method }) => {
-  const [open, setOpen] = useState(false)
+const ConfirmationPopUpController = ({ question, onAccept }) => {
+  const [open, setOpen] = useState(true)
 
   const onDecline = () => {
     setOpen(false)
@@ -14,9 +16,9 @@ const ConfirmationPopUpController = ({ query, method }) => {
 
   return (
     <ConfirmationPopUpView
-      query={query}
-      method={method}
+      question={question}
       open={open}
+      onAccept={onAccept}
       onDecline={onDecline}
     />
   )

--- a/frontend/src/components/popup/confirmation/ConfirmationPopUpView.jsx
+++ b/frontend/src/components/popup/confirmation/ConfirmationPopUpView.jsx
@@ -1,0 +1,16 @@
+import { Button, Dialog, Typography } from '@mui/material'
+import classes from './confirmationPopUp.module.scss'
+
+const ConfirmationPopUpView = ({ query, method, open, onDecline }) => (
+  <Dialog open={true}>
+    <div>
+      <Typography variant="h3">{query}</Typography>
+    </div>
+    <div className={classes.button}>
+      <Button onClick={onDecline}>No</Button>
+      <Button onClick={method}>Yes</Button>
+    </div>
+  </Dialog>
+)
+
+export default ConfirmationPopUpView

--- a/frontend/src/components/popup/confirmation/ConfirmationPopUpView.jsx
+++ b/frontend/src/components/popup/confirmation/ConfirmationPopUpView.jsx
@@ -2,13 +2,35 @@ import { Button, Dialog, Typography } from '@mui/material'
 import classes from './confirmationPopUp.module.scss'
 
 const ConfirmationPopUpView = ({ query, method, open, onDecline }) => (
-  <Dialog open={true}>
-    <div>
-      <Typography variant="h3">{query}</Typography>
+  <Dialog open={open}>
+    <div className={classes.title}>
+      <Typography variant="h6">{query}</Typography>
     </div>
     <div className={classes.button}>
-      <Button onClick={onDecline}>No</Button>
-      <Button onClick={method}>Yes</Button>
+      <Button
+        onClick={onDecline}
+        variant="outlined"
+        sx={{
+          maxWidth: '120px',
+          maxHeight: '50px',
+          minWidth: '120px',
+          minHeight: '50px',
+        }}
+      >
+        No
+      </Button>
+      <Button
+        onClick={method}
+        variant="contained"
+        sx={{
+          maxWidth: '120px',
+          maxHeight: '50px',
+          minWidth: '120px',
+          minHeight: '50px',
+        }}
+      >
+        Yes
+      </Button>
     </div>
   </Dialog>
 )

--- a/frontend/src/components/popup/confirmation/ConfirmationPopUpView.jsx
+++ b/frontend/src/components/popup/confirmation/ConfirmationPopUpView.jsx
@@ -1,10 +1,10 @@
 import { Button, Dialog, Typography } from '@mui/material'
 import classes from './confirmationPopUp.module.scss'
 
-const ConfirmationPopUpView = ({ query, method, open, onDecline }) => (
+const ConfirmationPopUpView = ({ question, open, onAccept, onDecline }) => (
   <Dialog open={open}>
     <div className={classes.title}>
-      <Typography variant="h6">{query}</Typography>
+      <Typography variant="h6">{question}</Typography>
     </div>
     <div className={classes.button}>
       <Button
@@ -20,7 +20,7 @@ const ConfirmationPopUpView = ({ query, method, open, onDecline }) => (
         No
       </Button>
       <Button
-        onClick={method}
+        onClick={onAccept}
         variant="contained"
         sx={{
           maxWidth: '120px',

--- a/frontend/src/components/popup/confirmation/confirmationPopUp.module.scss
+++ b/frontend/src/components/popup/confirmation/confirmationPopUp.module.scss
@@ -1,0 +1,6 @@
+.button {
+  // margin: 10px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}

--- a/frontend/src/components/popup/confirmation/confirmationPopUp.module.scss
+++ b/frontend/src/components/popup/confirmation/confirmationPopUp.module.scss
@@ -1,6 +1,17 @@
 .button {
-  // margin: 10px;
+  margin: 20px;
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-evenly;
+}
+
+.title {
+  margin-top: 50px;
+  margin-left: 60px;
+  margin-right: 60px;
+  margin-bottom: 20px;
+  max-width: 200px;
+  display: flex;
+  justify-content: center;
+  text-align: center;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Updog",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Updog",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# Description:
Fixes issue #153 

Have added a confirmation popup component for simple yes/no queries. This includes a view, a controller, and the relevant stylings needed. 

When it is being used, then there are four props to be considered: `question`, `open`, `onAccept`, `onDecline`. I don't expect onDecline to do more than dismiss the view, but I would say that it is better for us to pass through the action we want to take for onDecline and allow its control to be set up elsewhere rather than in the component to allow for that modularity. 

![image](https://user-images.githubusercontent.com/68832471/160280469-2d630d75-ce49-41ea-9cba-531be10cc429.png)

^^ A visual of it as an overlay over the profile settings.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [x] My code has been commented
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
