### PR TITLE
 [#202] Connected Loading Screen to the Other Pages

### DIFF
--- a/frontend/src/pages/dashboard/DashboardPageController.jsx
+++ b/frontend/src/pages/dashboard/DashboardPageController.jsx
@@ -1,5 +1,6 @@
 import DashboardPageView from './DashboardPageView'
 import useApi from '../../hooks/useApi'
+import LoadingView from '../loading/LoadingView'
 
 /**
  * This page renders a page which displays posts from user's followers. Each post is
@@ -9,7 +10,7 @@ const DashboardPageController = () => {
   const { data, loading, err } = useApi('feed')
 
   if (loading) {
-    return <div>Loading...</div>
+    return <LoadingView />
   }
 
   if (err) {

--- a/frontend/src/pages/follows/FollowsPageController.jsx
+++ b/frontend/src/pages/follows/FollowsPageController.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import FollowsPageView from './FollowsPageView'
 import useApi from '../../hooks/useApi'
+import LoadingView from '../loading/LoadingView'
 
 /**
  * This page renders a user's followers. It also contains
@@ -21,7 +22,7 @@ const FollowsPageController = () => {
   }, [data])
 
   if (loading) {
-    return <div>Loading...</div>
+    return <LoadingView />
   }
 
   if (error) {

--- a/frontend/src/pages/notifications/NotificationsPageController.jsx
+++ b/frontend/src/pages/notifications/NotificationsPageController.jsx
@@ -1,12 +1,12 @@
 import { List, ListItem } from '@mui/material'
 import { useEffect, useState } from 'react'
-import NotificationsPageView from './NotificationsPageView'
 import classes from './notificationspage.module.scss'
 import LikedNotification from '../../components/notifications/liked/LikedNotificationController'
+import NotificationsPageView from './NotificationsPageView'
+import LoadingView from '../loading/LoadingView'
 import SharedNotification from '../../components/notifications/shared/SharedNotificationController'
 import RepliedNotification from '../../components/notifications/replied/RepliedNotificationController'
 import useApi from '../../hooks/useApi'
-import LoadingView from '../loading/LoadingView'
 
 /**
  * This page renders a list of notifications for the user.

--- a/frontend/src/pages/notifications/NotificationsPageController.jsx
+++ b/frontend/src/pages/notifications/NotificationsPageController.jsx
@@ -6,6 +6,7 @@ import LikedNotification from '../../components/notifications/liked/LikedNotific
 import SharedNotification from '../../components/notifications/shared/SharedNotificationController'
 import RepliedNotification from '../../components/notifications/replied/RepliedNotificationController'
 import useApi from '../../hooks/useApi'
+import LoadingView from '../loading/LoadingView'
 
 /**
  * This page renders a list of notifications for the user.
@@ -58,7 +59,7 @@ const NotificationsPageController = () => {
   }, [data])
 
   if (loading) {
-    return <div>Loading...</div>
+    return <LoadingView />
   }
 
   if (err) {

--- a/frontend/src/pages/post/PostPageController.jsx
+++ b/frontend/src/pages/post/PostPageController.jsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 import PostPageView from './PostPageView'
-import useApi from '../../hooks/useApi'
 import LoadingView from '../loading/LoadingView'
+import useApi from '../../hooks/useApi'
 
 /**
  * This page renders a single post and its replies. It also contains

--- a/frontend/src/pages/post/PostPageController.jsx
+++ b/frontend/src/pages/post/PostPageController.jsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 import PostPageView from './PostPageView'
 import useApi from '../../hooks/useApi'
+import LoadingView from '../loading/LoadingView'
 
 /**
  * This page renders a single post and its replies. It also contains
@@ -12,7 +13,7 @@ const PostPageController = () => {
   const { data, loading, err } = useApi(`posts/${id}`)
 
   if (loading) {
-    return <div>Loading...</div>
+    return <LoadingView />
   }
 
   if (err) {

--- a/frontend/src/pages/postComposer/PostComposerController.jsx
+++ b/frontend/src/pages/postComposer/PostComposerController.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import LoadingView from '../loading/LoadingView'
 import PostComposerView from './PostComposerView'
 import useApi from '../../hooks/useApi'
 import { request } from '../../functions'
-import LoadingView from '../loading/LoadingView'
 
 const PostComposerController = () => {
   const [postText, setPostText] = useState('')

--- a/frontend/src/pages/postComposer/PostComposerController.jsx
+++ b/frontend/src/pages/postComposer/PostComposerController.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import PostComposerView from './PostComposerView'
 import useApi from '../../hooks/useApi'
 import { request } from '../../functions'
+import LoadingView from '../loading/LoadingView'
 
 const PostComposerController = () => {
   const [postText, setPostText] = useState('')
@@ -40,7 +41,7 @@ const PostComposerController = () => {
   }
 
   if (userLoading) {
-    return <div>Loading...</div>
+    return <LoadingView />
   }
 
   if (err) {

--- a/frontend/src/pages/profileSettings/ProfileSettingsController.jsx
+++ b/frontend/src/pages/profileSettings/ProfileSettingsController.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import ProfileSettingsView from './ProfileSettingsView'
 import useApi from '../../hooks/useApi'
+import LoadingView from '../loading/LoadingView'
 
 /**
  * This page is where users can edit their profile
@@ -12,7 +13,7 @@ const ProfileSettingsController = () => {
   // const [bannerModalOpen, setBannerModalOpen] = useState(false)
 
   if (loading) {
-    return <div>Loading...</div>
+    return <LoadingView />
   }
 
   if (err) {

--- a/frontend/src/pages/search/SearchPageController.jsx
+++ b/frontend/src/pages/search/SearchPageController.jsx
@@ -1,5 +1,6 @@
 import SearchPageView from './SearchPageView'
 import useApi from '../../hooks/useApi'
+import LoadingView from '../loading/LoadingView'
 
 /**
  * This page renders the search UI.
@@ -12,7 +13,7 @@ const SearchPageController = () => {
   }
 
   if (loading) {
-    return <div>Loading...</div>
+    return <LoadingView />
   }
 
   if (err) {

--- a/frontend/src/pages/user/UserPageController.jsx
+++ b/frontend/src/pages/user/UserPageController.jsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import LoadingView from '../loading/LoadingView'
 import UserPageView from './UserPageView'
 import useApi from '../../hooks/useApi'
 import { request } from '../../functions'
@@ -35,7 +36,7 @@ const UserPageController = () => {
   }, [followData])
 
   if (activityLoading || userLoading || followLoading) {
-    return <div>Loading...</div>
+    return <LoadingView />
   }
 
   if (err) {


### PR DESCRIPTION
# Description:
This PR is connected to issue #202. Where we connected the Loading page with the other pages. So that while we are waiting for something to Load it will display this page. The following gif is what the process looks like.

![ScreenLoading](https://user-images.githubusercontent.com/68896686/160541959-c5a4e15b-20cf-4f43-9e79-e2772744e1c0.gif)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [ ] My code has been commented
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
