### PR TITLE
[#216] Fix flaky search endpoint test

### DIFF
--- a/backend/server/controllers/search.js
+++ b/backend/server/controllers/search.js
@@ -52,6 +52,7 @@ const getUsersByQuery = async (query) => {
         { nickname: { [Sequelize.Op.like]: '%' + query + '%' } },
       ],
     },
+    order: [['createdAt', 'DESC']],
     raw: true,
   })
 }

--- a/backend/server/controllers/search.js
+++ b/backend/server/controllers/search.js
@@ -58,12 +58,8 @@ const getUsersByQuery = async (query) => {
 }
 
 const generateUserDtos = async (users) => {
-  const userDtos = []
-  await Promise.all(
-    users.map(async (user) => {
-      const userDto = await UserDTO.convertToDto(user)
-      userDtos.push(userDto)
-    })
+  const userDtos = await Promise.all(
+    users.map((user) => UserDTO.convertToDto(user))
   )
   return userDtos
 }


### PR DESCRIPTION
# Description:
Fixes a flaky backend search endpoint test which is failing on Github actions for all PRs until re-triggered.
The previous way await was being used in the generation of user dtos, resulted in the dto's being returned in different orders to the array.

Thanks @ff-dev-45 for spotting the bug!

Fixes #216 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project
- [x] My code has been commented
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
